### PR TITLE
bug fix: y_test[img, 0] to y_test[img_id, 0]

### DIFF
--- a/1_one-pixel-attack-cifar10.ipynb
+++ b/1_one-pixel-attack-cifar10.ipynb
@@ -965,7 +965,7 @@
     "                for target in targets:\n",
     "                    if targeted:\n",
     "                        print('Attacking with target', class_names[target])\n",
-    "                        if target == y_test[img, 0]:\n",
+    "                        if target == y_test[img_id, 0]:\n",
     "                            continue\n",
     "                    result = attack(img_id, model, target, pixel_count, \n",
     "                                    maxiter=maxiter, popsize=popsize, \n",


### PR DESCRIPTION
I guess `y_test[img, 0]` in `attack_all()` is a buggy line because `img` is not a valid variable in `attack_all()`. I guess the intended line was `y_test[img_id, 0]`?